### PR TITLE
added LocalExpirationMode enum to allow expire after update/read behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ spring:
       local:
         max-size: 2000
         expiry-jitter: 50
+        expiration-mode: after-create
       # Resilience4j Circuit Breaker properties for Redis
       circuit-breaker:
         failure-rate-threshold: 25

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ spring:
         max-size: 2000
         expiry-jitter: 50
         expiration-mode: after-create
+        # other valid values for expiration-mode: after-update, after-read
       # Resilience4j Circuit Breaker properties for Redis
       circuit-breaker:
         failure-rate-threshold: 25

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ SONATYPE_AUTOMATIC_RELEASE=true
 
 GROUP=io.github.suppierk
 POM_ARTIFACT_ID=spring-boot-multilevel-cache-starter
-VERSION_NAME=3.2.5.0
+VERSION_NAME=3.2.5.1
 POM_PACKAGING=jar
 
 POM_NAME=Spring Boot Multilevel Cache Starter

--- a/src/main/java/io/github/suppie/spring/cache/LocalExpirationMode.java
+++ b/src/main/java/io/github/suppie/spring/cache/LocalExpirationMode.java
@@ -1,7 +1,12 @@
 package io.github.suppie.spring.cache;
 
+import com.github.benmanes.caffeine.cache.Expiry;
+
 public enum LocalExpirationMode {
+  /** See {@link Expiry#expireAfterCreate(Object, Object, long)} */
   AFTER_CREATE,
+  /** See {@link Expiry#expireAfterUpdate(Object, Object, long, long)} */
   AFTER_UPDATE,
+  /** See {@link Expiry#expireAfterRead(Object, Object, long, long)} */
   AFTER_READ
 }

--- a/src/main/java/io/github/suppie/spring/cache/LocalExpirationMode.java
+++ b/src/main/java/io/github/suppie/spring/cache/LocalExpirationMode.java
@@ -1,0 +1,7 @@
+package io.github.suppie.spring.cache;
+
+public enum LocalExpirationMode {
+  AFTER_CREATE,
+  AFTER_UPDATE,
+  AFTER_READ
+}

--- a/src/main/java/io/github/suppie/spring/cache/MultiLevelCacheConfigurationProperties.java
+++ b/src/main/java/io/github/suppie/spring/cache/MultiLevelCacheConfigurationProperties.java
@@ -81,6 +81,7 @@ public class MultiLevelCacheConfigurationProperties {
     /** Percentage of time deviation for local cache entry expiration */
     private int expiryJitter = 50;
 
+    /** Optional local TTL */
     private Optional<Duration> timeToLive = Optional.empty();
 
     private LocalExpirationMode expirationMode = LocalExpirationMode.AFTER_CREATE;

--- a/src/main/java/io/github/suppie/spring/cache/MultiLevelCacheConfigurationProperties.java
+++ b/src/main/java/io/github/suppie/spring/cache/MultiLevelCacheConfigurationProperties.java
@@ -84,6 +84,7 @@ public class MultiLevelCacheConfigurationProperties {
     /** Optional local TTL */
     private Optional<Duration> timeToLive = Optional.empty();
 
+    /** Defaults to AFTER_CREATE to preserve previous behavior */
     private LocalExpirationMode expirationMode = LocalExpirationMode.AFTER_CREATE;
   }
 

--- a/src/main/java/io/github/suppie/spring/cache/MultiLevelCacheConfigurationProperties.java
+++ b/src/main/java/io/github/suppie/spring/cache/MultiLevelCacheConfigurationProperties.java
@@ -26,6 +26,7 @@ package io.github.suppie.spring.cache;
 
 import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig.SlidingWindowType;
 import java.time.Duration;
+import java.util.Optional;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
@@ -79,6 +80,8 @@ public class MultiLevelCacheConfigurationProperties {
 
     /** Percentage of time deviation for local cache entry expiration */
     private int expiryJitter = 50;
+
+    private Optional<Duration> timeToLive = Optional.empty();
 
     private LocalExpirationMode expirationMode = LocalExpirationMode.AFTER_CREATE;
   }

--- a/src/main/java/io/github/suppie/spring/cache/MultiLevelCacheConfigurationProperties.java
+++ b/src/main/java/io/github/suppie/spring/cache/MultiLevelCacheConfigurationProperties.java
@@ -79,6 +79,8 @@ public class MultiLevelCacheConfigurationProperties {
 
     /** Percentage of time deviation for local cache entry expiration */
     private int expiryJitter = 50;
+
+    private LocalExpirationMode expirationMode = LocalExpirationMode.AFTER_CREATE;
   }
 
   /**

--- a/src/main/java/io/github/suppie/spring/cache/MultiLevelCacheManager.java
+++ b/src/main/java/io/github/suppie/spring/cache/MultiLevelCacheManager.java
@@ -124,7 +124,7 @@ public class MultiLevelCacheManager implements CacheManager {
     return Collections.unmodifiableSet(availableCaches.keySet());
   }
 
-  /** Expiry policy enabling randomized expiry on writing for local entities */
+  /** Expiry policy enabling randomized expiry for local entities */
   static class RandomizedLocalExpiry implements Expiry<Object, Object> {
 
     private final Duration timeToLive;

--- a/src/test/java/io/github/suppie/spring/cache/MultiLevelCacheManagerTest.java
+++ b/src/test/java/io/github/suppie/spring/cache/MultiLevelCacheManagerTest.java
@@ -24,7 +24,7 @@
 
 package io.github.suppie.spring.cache;
 
-import io.github.suppie.spring.cache.MultiLevelCacheManager.RandomizedLocalExpiryOnWrite;
+import io.github.suppie.spring.cache.MultiLevelCacheManager.RandomizedLocalExpiry;
 import java.time.Duration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
@@ -66,7 +66,7 @@ class MultiLevelCacheManagerTest extends AbstractRedisIntegrationTest {
 
       Assertions.assertThrows(
           IllegalArgumentException.class,
-          () -> new RandomizedLocalExpiryOnWrite(properties),
+          () -> new RandomizedLocalExpiry(properties),
           "Negative TTL must throw an exception");
     }
 
@@ -78,7 +78,7 @@ class MultiLevelCacheManagerTest extends AbstractRedisIntegrationTest {
 
       Assertions.assertThrows(
           IllegalArgumentException.class,
-          () -> new RandomizedLocalExpiryOnWrite(properties),
+          () -> new RandomizedLocalExpiry(properties),
           "Zero TTL must throw an exception");
     }
 
@@ -90,7 +90,7 @@ class MultiLevelCacheManagerTest extends AbstractRedisIntegrationTest {
 
       Assertions.assertThrows(
           IllegalArgumentException.class,
-          () -> new RandomizedLocalExpiryOnWrite(properties),
+          () -> new RandomizedLocalExpiry(properties),
           "Negative expiry jitter must throw an exception");
     }
 
@@ -102,7 +102,7 @@ class MultiLevelCacheManagerTest extends AbstractRedisIntegrationTest {
 
       Assertions.assertThrows(
           IllegalArgumentException.class,
-          () -> new RandomizedLocalExpiryOnWrite(properties),
+          () -> new RandomizedLocalExpiry(properties),
           "Too big expiry jitter must throw an exception");
     }
   }

--- a/src/test/java/io/github/suppie/spring/cache/MultiLevelCacheManagerTest.java
+++ b/src/test/java/io/github/suppie/spring/cache/MultiLevelCacheManagerTest.java
@@ -26,6 +26,7 @@ package io.github.suppie.spring.cache;
 
 import io.github.suppie.spring.cache.MultiLevelCacheManager.RandomizedLocalExpiry;
 import java.time.Duration;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -57,7 +58,7 @@ class MultiLevelCacheManagerTest extends AbstractRedisIntegrationTest {
   }
 
   @Nested
-  class RandomizedLocalExpiryOnWriteTest {
+  class RandomizedLocalExpiryTest {
     @Test
     void negativeTimeToLive() {
       MultiLevelCacheConfigurationProperties properties =
@@ -104,6 +105,30 @@ class MultiLevelCacheManagerTest extends AbstractRedisIntegrationTest {
           IllegalArgumentException.class,
           () -> new RandomizedLocalExpiry(properties),
           "Too big expiry jitter must throw an exception");
+    }
+
+    @Test
+    void negativeLocalTimeToLive() {
+      MultiLevelCacheConfigurationProperties properties =
+          new MultiLevelCacheConfigurationProperties();
+      properties.getLocal().setTimeToLive(Optional.of(Duration.ofSeconds(1).negated()));
+
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> new RandomizedLocalExpiry(properties),
+          "Negative TTL must throw an exception");
+    }
+
+    @Test
+    void zeroLocalTimeToLive() {
+      MultiLevelCacheConfigurationProperties properties =
+          new MultiLevelCacheConfigurationProperties();
+      properties.getLocal().setTimeToLive(Optional.of(Duration.ZERO));
+
+      Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> new RandomizedLocalExpiry(properties),
+          "Zero TTL must throw an exception");
     }
   }
 }


### PR DESCRIPTION
I want my local cache to have expire after access semantics instead of expire after create. This should allow that by simply setting `spring.cache.multilevel.local.expiration-mode=after-read`. Also enables a different TTL for local cache vs Redis. Local could be 15 minutes vs 1 hour for Redis, for example.

I haven't added any tests yet. If you are open to this change, I'll go ahead and add tests.