### PR TITLE
Fix MultiLevelCacheConfigurationProperties.toRedisCacheConfiguration.

### DIFF
--- a/src/main/java/io/github/suppie/spring/cache/MultiLevelCacheConfigurationProperties.java
+++ b/src/main/java/io/github/suppie/spring/cache/MultiLevelCacheConfigurationProperties.java
@@ -70,7 +70,7 @@ public class MultiLevelCacheConfigurationProperties {
         throw new IllegalStateException(
             "Property 'spring.cache.multilevel.key-prefix' must be set when 'use-key-prefix' is true");
       }
-      configuration.prefixCacheNameWith(keyPrefix);
+      configuration = configuration.prefixCacheNameWith(keyPrefix);
     }
 
     return configuration;


### PR DESCRIPTION
the RedisCacheConfiguration is immutable.

 All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
